### PR TITLE
Updated Installation Intructions for CMake

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -58,8 +58,12 @@ The following build instructions comply with Ubuntu 20.04 and Amazon Linux 2 env
     To get and use the latest version of cmake:
 
     ```
-    wget https://github.com/Kitware/CMake/releases/download/v3.20.6/cmake-3.20.6-linux-x86_64.sh
-    sh cmake-3.20.6-linux-x86_64.sh
+    wget https://github.com/Kitware/CMake/releases/download/v3.23.2/cmake-3.23.2.tar.gz
+    tar vfxz cmake-3.23.2.tar.gz
+    cd cmake-3.23.2
+    ./bootstrap 
+    make
+    sudo make install
     ```
 
 


### PR DESCRIPTION
Currently, the instructions for installing CMake do not immediately work
as intended. The instructions are also not for the latest version
release. This commit updates the instructions to CMake 3.23.2 and
streamlines the process by retrieving from the .tar file.

Task:

Signed-off-by: Ozzy Nolen <oscarno@amazon.com>

This commit updates the instructions to CMake 3.23.2 and
streamlines the process by retrieving from the .tar file.

[Describe what this change achieves]
 
- CMake installation instructions do not work well
- Instructions use an old version of CMake

[List any issues this PR will resolve]


### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).